### PR TITLE
Add iputils-ping to Dockerfile dependencies

### DIFF
--- a/VIDEO/Dockerfile
+++ b/VIDEO/Dockerfile
@@ -54,6 +54,7 @@ RUN set -ex && \
         libswscale-dev \
         libmagic1 \
         ffmpeg \
+        iputils-ping \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
解决在video-service容器中,ping命令用不了，导致摄像头的状态不能显示在线