### PR TITLE
fix(gb28181): resolve catalog channel wiring issues

### DIFF
--- a/DEVICE/iot-gb28181/iot-gb28181-biz/src/main/java/com/genersoft/iot/vmp/gb28181/dao/CommonGBChannelMapper.java
+++ b/DEVICE/iot-gb28181/iot-gb28181-biz/src/main/java/com/genersoft/iot/vmp/gb28181/dao/CommonGBChannelMapper.java
@@ -322,7 +322,7 @@ public interface CommonGBChannelMapper {
     List<CommonGBChannel> queryByCivilCode(@Param("civilCode") String civilCode);
 
     @SelectProvider(type = ChannelProvider.class, method = "queryByDataTypeAndDeviceIds")
-    List<CommonGBChannel> queryByDataTypeAndDeviceIds(@Param("dataType") Integer dataType, List<Integer> deviceIds);
+    List<CommonGBChannel> queryByDataTypeAndDeviceIds(@Param("dataType") Integer dataType, @Param("deviceIds") List<Integer> deviceIds);
 
     @SelectProvider(type = ChannelProvider.class, method = "queryByGbDeviceIds")
     List<CommonGBChannel> queryByGbDeviceIds(List<String> deviceIds);

--- a/DEVICE/iot-gb28181/iot-gb28181-biz/src/main/java/com/genersoft/iot/vmp/gb28181/session/CatalogDataManager.java
+++ b/DEVICE/iot-gb28181/iot-gb28181-biz/src/main/java/com/genersoft/iot/vmp/gb28181/session/CatalogDataManager.java
@@ -7,6 +7,7 @@ import com.genersoft.iot.vmp.gb28181.service.IRegionService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -24,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 public class CatalogDataManager implements CommandLineRunner {
 
     @Autowired
+    @Lazy
     private IDeviceChannelService deviceChannelService;
 
     @Autowired

--- a/DEVICE/iot-gb28181/iot-gb28181-biz/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/response/cmd/CatalogResponseMessageHandler.java
+++ b/DEVICE/iot-gb28181/iot-gb28181-biz/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/response/cmd/CatalogResponseMessageHandler.java
@@ -16,6 +16,7 @@ import org.dom4j.DocumentException;
 import org.dom4j.Element;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +47,7 @@ public class CatalogResponseMessageHandler extends SIPRequestProcessorParent imp
     private final ConcurrentLinkedQueue<HandlerCatchData> taskQueue = new ConcurrentLinkedQueue<>();
 
     @Autowired
+    @Lazy
     private IDeviceChannelService deviceChannelService;
 
     @Autowired


### PR DESCRIPTION
fix mybatis BindingException: Parameter 'deviceIds' not found.

fix BeanCurrentlyInCreationException: Error creating bean with name 'deviceChannelServiceImpl': Bean with name 'deviceChannelServiceImpl' has been injected into other beans [catalogDataManager] in its raw version as part of a circular reference, but has eventually been wrapped.